### PR TITLE
Add toleration for new control-plane taint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add toleration for new control-plane taint.
+- Generate `values.schema.json` with `helm schema-gen`.
 
 ## [0.2.1] - 2022-01-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add toleration for new control-plane taint.
+
 ## [0.2.1] - 2022-01-28
 
 ### Added

--- a/helm/calico-app/templates/deployment.yaml
+++ b/helm/calico-app/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
           operator: Exists
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       serviceAccountName: {{ include "resource.default.name" . }}-kube-controllers
       priorityClassName: system-cluster-critical
       containers:

--- a/helm/calico-app/values.schema.json
+++ b/helm/calico-app/values.schema.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "image": {
+            "type": "object",
+            "properties": {
+                "cni": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "flexvol": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "kube_controllers": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "node": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "name": {
+            "type": "string"
+        },
+        "project": {
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "type": "string"
+                },
+                "commit": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a toleration for the `node-role.kubernetes.io/control-plane` taint to resources that already have a toleration to the deprecated `node-role.kubernetes.io/master` taint.

Towards https://github.com/giantswarm/roadmap/issues/2468
